### PR TITLE
Feat/validate

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,12 +16,11 @@ module.exports = {
   },
   rules: {
     eqeqeq: ['error', 'always'],
-    'no-import-assign': 'error',
     'prefer-regex-literals': 'error',
     'default-param-last': 'error',
     // Overwrites
     '@typescript-eslint/no-unused-vars': 'error',
-    '@typescript-eslint/no-empty-interface': 'warn'
+    '@typescript-eslint/no-empty-interface': 'warn',
   },
   reportUnusedDisableDirectives: true,
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "ajv": "^6.10.2",
     "execa": "^2.0.4",
     "glob": "^7.1.4",
+    "js-yaml": "^3.13.1",
     "json-schema-to-typescript": "^7.1.0",
     "ramda": "^0.26.1"
   }

--- a/src/load.test.ts
+++ b/src/load.test.ts
@@ -61,7 +61,7 @@ const alreadyLoadedConfig = {
   runtimeEnvironment: RUNTIME_ENVIRONMENT,
 }
 
-describe('load behaves as expected', () => {
+describe('load()', () => {
   const OLD_ENV = process.env
 
   beforeEach(() => {
@@ -92,7 +92,10 @@ describe('load behaves as expected', () => {
   it('reads the config based on process.env.RUNTIME_ENVIRONMENT', () => {
     load()
 
-    expect(mockedReadConfigFile).toHaveBeenCalledWith(RUNTIME_ENVIRONMENT)
+    expect(mockedReadConfigFile).toHaveBeenCalledWith(
+      expect.any(String),
+      RUNTIME_ENVIRONMENT
+    )
   })
 
   it('decrypts the config with SOPS', () => {

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,53 +1,53 @@
-import R from "ramda";
-import { generateTypeFromSchema } from "./utils/generate-type-from-schema";
-import { hydrateConfig } from "./utils/hydrate-config";
-import { validateConfig } from "./utils/validate-config";
-import { readConfigFile, readSchemaFile } from "./utils/read-file";
-import * as sops from "./utils/sops";
+import R from 'ramda'
+import { generateTypeFromSchema } from './utils/generate-type-from-schema'
+import { hydrateConfig } from './utils/hydrate-config'
+import { validateConfig } from './utils/validate-config'
+import { readConfigFile, readSchemaFile } from './utils/read-file'
+import * as sops from './utils/sops'
 
-let memoizedConfig: MemoizedConfig = undefined;
+let memoizedConfig: MemoizedConfig = undefined
 
 export const getMemoizedConfig = (): MemoizedConfig => {
-  return memoizedConfig;
-};
+  return memoizedConfig
+}
 
 export const clearMemoizedConfig = (): void => {
-  memoizedConfig = undefined;
-};
+  memoizedConfig = undefined
+}
 
 export const load = (
   passedConfig: MemoizedConfig = memoizedConfig
 ): HydratedConfig => {
   if (R.isNil(process.env.RUNTIME_ENVIRONMENT)) {
-    throw new Error("process.env.RUNTIME_ENVIRONMENT must be defined.");
+    throw new Error('process.env.RUNTIME_ENVIRONMENT must be defined.')
   }
 
   if (!R.isNil(passedConfig)) {
     memoizedConfig = {
       ...passedConfig,
-      runtimeEnvironment: process.env.RUNTIME_ENVIRONMENT
-    };
-    return memoizedConfig;
+      runtimeEnvironment: process.env.RUNTIME_ENVIRONMENT,
+    }
+    return memoizedConfig
   }
 
-  const configFile = readConfigFile(process.env.RUNTIME_ENVIRONMENT);
+  const configFile = readConfigFile(`./config`, process.env.RUNTIME_ENVIRONMENT)
 
   const decrypted = sops.decryptToObject(
     configFile.filePath,
     configFile.contents
-  );
+  )
 
-  const config = hydrateConfig(process.env.RUNTIME_ENVIRONMENT)(decrypted);
+  const config = hydrateConfig(process.env.RUNTIME_ENVIRONMENT)(decrypted)
 
-  const schemaFile = readSchemaFile("schema");
+  const schemaFile = readSchemaFile('schema')
 
   if (schemaFile !== undefined) {
-    validateConfig(config, schemaFile.contents);
+    validateConfig(config, schemaFile.contents)
 
-    generateTypeFromSchema("config/schema.json");
+    generateTypeFromSchema('config/schema.json')
   }
 
-  memoizedConfig = config;
+  memoizedConfig = config
 
-  return config;
-};
+  return config
+}

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,53 +1,53 @@
-import R from 'ramda'
-import { generateTypeFromSchema } from './utils/generate-type-from-schema'
-import { hydrateConfig } from './utils/hydrate-config'
-import { validateConfig } from './utils/validate-config'
-import { readConfigFile, readSchemaFile } from './utils/read-file'
-import * as sops from './utils/sops'
+import R from "ramda";
+import { generateTypeFromSchema } from "./utils/generate-type-from-schema";
+import { hydrateConfig } from "./utils/hydrate-config";
+import { validateConfig } from "./utils/validate-config";
+import { readConfigFile, readSchemaFile } from "./utils/read-file";
+import * as sops from "./utils/sops";
 
-let memoizedConfig: MemoizedConfig = undefined
+let memoizedConfig: MemoizedConfig = undefined;
 
 export const getMemoizedConfig = (): MemoizedConfig => {
-  return memoizedConfig
-}
+  return memoizedConfig;
+};
 
 export const clearMemoizedConfig = (): void => {
-  memoizedConfig = undefined
-}
+  memoizedConfig = undefined;
+};
 
 export const load = (
   passedConfig: MemoizedConfig = memoizedConfig
 ): HydratedConfig => {
   if (R.isNil(process.env.RUNTIME_ENVIRONMENT)) {
-    throw new Error('process.env.RUNTIME_ENVIRONMENT must be defined.')
+    throw new Error("process.env.RUNTIME_ENVIRONMENT must be defined.");
   }
 
   if (!R.isNil(passedConfig)) {
     memoizedConfig = {
       ...passedConfig,
-      runtimeEnvironment: process.env.RUNTIME_ENVIRONMENT,
-    }
-    return memoizedConfig
+      runtimeEnvironment: process.env.RUNTIME_ENVIRONMENT
+    };
+    return memoizedConfig;
   }
 
-  const configFile = readConfigFile(process.env.RUNTIME_ENVIRONMENT)
+  const configFile = readConfigFile(process.env.RUNTIME_ENVIRONMENT);
 
   const decrypted = sops.decryptToObject(
     configFile.filePath,
     configFile.contents
-  )
+  );
 
-  const config = hydrateConfig(process.env.RUNTIME_ENVIRONMENT)(decrypted)
+  const config = hydrateConfig(process.env.RUNTIME_ENVIRONMENT)(decrypted);
 
-  const schemaFile = readSchemaFile('schema')
+  const schemaFile = readSchemaFile("schema");
 
   if (schemaFile !== undefined) {
-    validateConfig(config, schemaFile.contents)
+    validateConfig(config, schemaFile.contents);
 
-    generateTypeFromSchema('config/schema.json')
+    generateTypeFromSchema("config/schema.json");
   }
 
-  memoizedConfig = config
+  memoizedConfig = config;
 
-  return config
-}
+  return config;
+};

--- a/src/utils/find-files.test.ts
+++ b/src/utils/find-files.test.ts
@@ -1,0 +1,103 @@
+jest.mock('glob')
+jest.mock('path')
+jest.mock('./read-file')
+import glob from 'glob'
+import path from 'path'
+import { getFileExtensionPattern } from './read-file'
+const mockedGlob = glob as jest.Mocked<typeof glob>
+const mockedPath = path as jest.Mocked<typeof path>
+const mockedGetFileExtensionPattern = getFileExtensionPattern as jest.MockedFunction<
+  typeof getFileExtensionPattern
+>
+
+const mockedFileNames = ['/dev/config/development.yml', 'schema.json']
+const mockedResolvedPath = '/dev'
+mockedGlob.sync = jest.fn().mockReturnValue(mockedFileNames)
+mockedPath.resolve = jest.fn().mockReturnValue(mockedResolvedPath)
+mockedGetFileExtensionPattern.mockReturnValue('json')
+
+import { findConfigFiles, findFiles, isSchema } from './find-files'
+
+describe('findFiles()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('invokes glob.sync', () => {
+    findFiles('some/path')
+
+    expect(mockedGlob.sync).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns result of glob.sync', () => {
+    expect(findFiles('some/path')).toEqual(mockedFileNames)
+  })
+
+  it('invokes glob.sync with correct default glob', () => {
+    findFiles('some/path')
+
+    expect(mockedGlob.sync).toHaveBeenCalledWith('**/*.*', expect.any(Object))
+  })
+
+  it('builds non-default glob correctly', () => {
+    findFiles('some/path', 'schema', 'json')
+
+    expect(mockedGlob.sync).toHaveBeenCalledWith(
+      'schema.json',
+      expect.any(Object)
+    )
+  })
+
+  it('invokes glob.sync with correct options', () => {
+    findFiles('some/path')
+
+    expect(mockedGlob.sync).toHaveBeenCalledWith(expect.any(String), {
+      cwd: mockedResolvedPath,
+      absolute: true,
+    })
+  })
+})
+
+describe('isSchema()', () => {
+  it('returns false for paths where the filename does not start with schema', () => {
+    expect(isSchema('/dev/config/development.yaml')).toBe(false)
+  })
+
+  it('returns true for paths where the filename starts withs schema', () => {
+    expect(isSchema('/dev/config/schema.json')).toBe(true)
+  })
+})
+
+describe('findConfigFiles()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('invokes glob.sync', () => {
+    findConfigFiles('some/path')
+
+    expect(mockedGlob.sync).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns result of glob.sync but filters out files named schema', () => {
+    expect(findConfigFiles('some/path')).toEqual([mockedFileNames[0]])
+  })
+
+  it('invokes glob.sync with correct default glob', () => {
+    findConfigFiles('some/path')
+
+    expect(mockedGlob.sync).toHaveBeenCalledWith(
+      '**/*.json',
+      expect.any(Object)
+    )
+  })
+
+  it('builds glob correctly when fileName is passed', () => {
+    findConfigFiles('some/path', 'schema')
+
+    expect(mockedGlob.sync).toHaveBeenCalledWith(
+      'schema.json',
+      expect.any(Object)
+    )
+  })
+})

--- a/src/utils/find-files.ts
+++ b/src/utils/find-files.ts
@@ -1,0 +1,28 @@
+import R from 'ramda'
+import path from 'path'
+import glob from 'glob'
+
+import { getFileExtensionPattern } from './read-file'
+
+export const isSchema = (filePath: string): boolean =>
+  R.compose<string, string[], string, boolean>(
+    fileName => fileName.startsWith('schema'),
+    R.last,
+    R.split('/')
+  )(filePath)
+
+export const findFiles = (
+  basePath: string,
+  globFileName = '**/*',
+  globFileExtension = '*'
+): string[] => {
+  const globPattern = `${globFileName}.${globFileExtension}`
+
+  return glob.sync(globPattern, { cwd: path.resolve(basePath), absolute: true })
+}
+
+export const findConfigFiles = (
+  basePath: string,
+  fileName?: string
+): string[] =>
+  R.reject(isSchema, findFiles(basePath, fileName, getFileExtensionPattern()))

--- a/src/utils/generate-type-from-schema.test.ts
+++ b/src/utils/generate-type-from-schema.test.ts
@@ -45,7 +45,7 @@ mockedCompileFromFile.mockResolvedValue(mockedCompiledTypes)
 
 import { pascalCase, generateTypeFromSchema } from './generate-type-from-schema'
 
-describe('pascalCase behaves as expected', () => {
+describe('pascalCase()', () => {
   test.each([
     ['name', 'Name'],
     ['some-name', 'SomeName'],
@@ -57,7 +57,7 @@ describe('pascalCase behaves as expected', () => {
   })
 })
 
-describe('generateTypeFromSchema behaves as expected', () => {
+describe('generateTypeFromSchema()', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })

--- a/src/utils/get-file-from-path.test.ts
+++ b/src/utils/get-file-from-path.test.ts
@@ -1,0 +1,94 @@
+jest.mock('fs')
+jest.mock('js-yaml')
+
+import fs from 'fs'
+import yaml from 'js-yaml'
+
+const mockedFs = fs as jest.Mocked<typeof fs>
+const mockedYaml = yaml as jest.Mocked<typeof yaml>
+
+mockedFs.readFileSync = jest
+  .fn()
+  .mockReturnValue('parsed config in json or yaml format')
+mockedYaml.load = jest.fn().mockReturnValue({ parsed: 'yaml' })
+const pathToFile = 'some/path/to/file.yaml'
+
+import {
+  readFileToString,
+  isJson,
+  getFileFromPath,
+  parseToJson,
+} from './get-file-from-path'
+
+describe('readFileToString()', () => {
+  it('reads correct path', () => {
+    readFileToString(pathToFile)
+
+    expect(mockedFs.readFileSync).toHaveBeenCalledWith(pathToFile)
+  })
+
+  it('always returns string', () => {
+    mockedFs.readFileSync.mockReturnValueOnce(Buffer.from('some buffer'))
+
+    expect(readFileToString(pathToFile)).toBe('some buffer')
+  })
+})
+
+describe('isJson()', () => {
+  it('returns true when passed filePath ends with .json', () => {
+    expect(isJson('/dev/path/to/some/json/file.json')).toBe(true)
+  })
+
+  it('returns false when passed filePath does not end with .json', () => {
+    expect(isJson('/dev/path/to/some/json/file.yml')).toBe(false)
+  })
+})
+
+describe('parseToJson()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('parses YAML if YAML file is passed', () => {
+    parseToJson('/path/to/json/file.yml')('file: "yaml"')
+
+    expect(mockedYaml.load).toHaveBeenCalledTimes(1)
+  })
+
+  it('parses not YAML if JSON file is passed', () => {
+    parseToJson('/path/to/json/file.json')('{}')
+
+    expect(mockedYaml.load).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('getFileFromPath()', () => {
+  const innerParse = jest.fn().mockReturnValue({ parsed: 'tojson' })
+
+  beforeAll(() => {
+    readFileToString = jest.fn().mockReturnValue('string')
+    parseToJson = jest.fn(() => innerParse)
+  })
+
+  it('reads the file to string', () => {
+    getFileFromPath('some/path/config.yaml')
+
+    expect(readFileToString).toHaveBeenCalledWith('some/path/config.yaml')
+  })
+
+  it('parses the string to json', () => {
+    getFileFromPath('some/path/config.yaml')
+
+    expect(parseToJson).toHaveBeenCalledWith('some/path/config.yaml')
+    expect(innerParse).toHaveBeenCalledWith('string')
+  })
+
+  it('returns the expected file', () => {
+    const result = getFileFromPath('some/path/config.yaml')
+
+    expect(result).toStrictEqual({
+      filePath: 'some/path/config.yaml',
+      contents: { parsed: 'tojson' },
+    })
+  })
+})

--- a/src/utils/get-file-from-path.ts
+++ b/src/utils/get-file-from-path.ts
@@ -1,0 +1,26 @@
+import R from 'ramda'
+import fs from 'fs'
+import yaml from 'js-yaml'
+
+import { File } from './read-file'
+
+export const readFileToString = (filePath: string): string =>
+  fs.readFileSync(filePath).toString()
+
+export const isJson = R.compose<string, string[], string, boolean>(
+  R.equals('json'),
+  R.last,
+  R.split('.')
+)
+
+export const parseToJson = (filePath: string) => (
+  fileAsString: string
+): JSONObject =>
+  isJson(filePath) ? JSON.parse(fileAsString) : yaml.load(fileAsString)
+
+export const getFileFromPath = (filePath: string): File =>
+  R.compose<string, string, JSONObject, File>(
+    contents => ({ contents, filePath }),
+    parseToJson(filePath),
+    readFileToString
+  )(filePath)

--- a/src/utils/hydrate-config.test.ts
+++ b/src/utils/hydrate-config.test.ts
@@ -20,7 +20,7 @@ mockedSubstituteWithEnv.mockReturnValue(mockedSubstitutedConfig)
 import { hydrateConfig } from './hydrate-config'
 const hydrateConfigInited = hydrateConfig(mockedRuntimeEnvironment)
 
-describe('hydrateConfig behaves as expected', () => {
+describe('hydrateConfig()', () => {
   it('calls substituteWithEnv', () => {
     hydrateConfigInited(mockedConfig)
 

--- a/src/utils/sops.test.ts
+++ b/src/utils/sops.test.ts
@@ -31,7 +31,7 @@ mockedYaml.load = jest.fn().mockReturnValue('some: yaml')
 
 import { decryptToObject, decryptInPlace } from './sops'
 
-describe('decryptToObject behaves as expected', () => {
+describe('decryptToObject()', () => {
   it('returns the parsed config as-is when it does not contain SOPS metadata (nothing to decrypt)', () => {
     const result = decryptToObject(mockedFilePath, mockedParsedConfigNoSops)
 
@@ -65,7 +65,7 @@ describe('decryptToObject behaves as expected', () => {
   })
 })
 
-describe('decryptInPlace works as expected', () => {
+describe('decryptInPlace()', () => {
   it('calls the SOPS binary with the flag "--in-place"', () => {
     decryptInPlace(mockedFilePath)
 

--- a/src/utils/substitute-with-env.test.ts
+++ b/src/utils/substitute-with-env.test.ts
@@ -6,7 +6,7 @@ const mockedProcessEnv = {
   '0INVALID': 'INVALID KEY',
 }
 
-describe('substituteWithEnv behaves as expected', () => {
+describe('substituteWithEnv()', () => {
   const OLD_PROCESS_ENV = process.env
 
   beforeAll(() => {

--- a/src/utils/validate-config.test.ts
+++ b/src/utils/validate-config.test.ts
@@ -1,4 +1,4 @@
-describe('validateConfig works as expected', () => {
+describe('validateConfig()', () => {
   test.todo('compiles the schema')
 
   test.todo('validates the config agains the schema')

--- a/src/utils/validate-config.ts
+++ b/src/utils/validate-config.ts
@@ -2,10 +2,7 @@ import Ajv from 'ajv'
 
 const ajv = new Ajv({ useDefaults: true })
 
-export const validateConfig = (
-  config: HydratedConfig,
-  schema: Schema
-): true => {
+export const validateConfig = (config: BaseConfig, schema: Schema): true => {
   const validate = ajv.compile(schema)
 
   if (!validate(config)) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,9 +1,50 @@
 import R from 'ramda'
+import fs from 'fs'
+import path from 'path'
+import { findConfigFiles } from './utils/find-files'
+import { getFileFromPath } from './utils/get-file-from-path'
+import { validateConfig } from './utils/validate-config'
 
-export const validate = (schema: Schema): true => {
-  if (R.isNil(schema)) {
-    throw new Error('Config does not match the specified schema')
+const validateConfigAgainstSchema = (schema: Schema) => (
+  configFilePath: string
+): true => {
+  const configFile = getFileFromPath(configFilePath)
+
+  return validateConfig(configFile.contents, schema)
+}
+
+export const validate = (
+  schemaPath: string,
+  ...configPaths: string[]
+): true => {
+  if (R.isNil(schemaPath)) {
+    throw new Error('Schema path must be passed to validate config files')
   }
+
+  if (R.isNil(configPaths) || R.isEmpty(configPaths)) {
+    throw new Error('Config path(s) must be passed so they can be validated')
+  }
+
+  const schemaFile = getFileFromPath(schemaPath)
+  const validateConfig = validateConfigAgainstSchema(schemaFile.contents)
+
+  if (R.isNil(schemaFile)) {
+    throw new Error('Could not find a schema for validation')
+  }
+
+  // Resolve absolute paths of all given `configPaths`, which can be passed as directories and/or files
+  // TODO: Figure out correct type here. Error: R.compose<string[], (string | string[])[], string[]>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const flatConfigPaths = R.compose<string[], any[], string[]>(
+    R.flatten,
+    R.map(configPath =>
+      fs.lstatSync(configPath).isDirectory()
+        ? findConfigFiles(configPath)
+        : path.resolve(configPath)
+    )
+  )(configPaths)
+
+  flatConfigPaths.forEach(validateConfig)
 
   return true
 }


### PR DESCRIPTION
### Donezo:

- [x] Expose a `validate()` function besides existing `load()`
- [x] Refactor io-related code to make it more generic, re-usable and easier to test

The `validate()` functions returns `true` if the validation(s) pass, and throws an Error otherwise. It can be used as part of tests, and/or CI to validate configs without returning them. The function signature is:

```js
// x = path to schema file
// y = path to config folder or a config file
function validate = (<x>, <y>, [...<y>]) => true | Error

// Example calls
validate('config/schema.json', 'config')
validate('config/schema.json', '../config')
validate('config/schema.json', '../config', '/path/to/other/config/file.yaml')
```

In words: Firstly, it requires a `schema.json` to validate against. Secondly, it accepts a list of config paths (can be dirs or files), which are passed as variadic parameters.

fixes https://github.com/strong-config/node/issues/10

### How to test

1. Checkout this branch, Checkout another project like api-gateway locally (master)
2. `yarn build` strong-config
3. in api-gateway: `yarn remove @brickblock/strong-config`, `yarn add <path to local 
@strong-config/node>`
4. In `api-gateway/src/index.js`, replace occurrences of `@brickblock/strong-config` with `@strong-config/node`. In the same file, add

```js
const validationResult = require('@strong-config/node').validate(
  'config/schema.json',
  'config/development.yml'
)
console.log(validationResult)
```

5. When you `yarn start` the api-gateway, it should print `true` to the console. If you play around with config files or the schema, it will throw instead.
