### PR TITLE
Refactor/class instantiation

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,11 +1,57 @@
-import * as strongConfig from './index'
+jest.mock('./load')
+jest.mock('./validate')
 
-describe('strong-config exports are as expected', () => {
-  it('exports a load function', () => {
-    expect(strongConfig.load).toBeInstanceOf(Function)
+import { load } from './load'
+import { validate } from './validate'
+
+const mockedLoad = load as jest.MockedFunction<typeof load>
+const mockedValidate = validate as jest.MockedFunction<typeof validate>
+
+const mockedConfig = { some: 'config', runtimeEnvironment: 'development' }
+const mockedValidationResult = true
+mockedLoad.mockReturnValue(mockedConfig)
+mockedValidate.mockReturnValue(mockedValidationResult)
+
+import StrongConfig from './index'
+
+describe('StrongConfig class', () => {
+  it('StrongConfig is a class that can be instantiated', () => {
+    expect(new StrongConfig()).toBeDefined()
   })
 
-  it('exports a validate function', () => {
-    expect(strongConfig.validate).toBeInstanceOf(Function)
+  it('StrongConfig accepts and stores a configuration object', () => {
+    const mockConfiguration = {}
+    const strongConfig = new StrongConfig(mockConfiguration)
+
+    expect(strongConfig.configuration).toStrictEqual(mockConfiguration)
+  })
+
+  it('strongConfig exposes "load()"', () => {
+    expect(new StrongConfig().load).toBeInstanceOf(Function)
+  })
+
+  it('strongConfig exposes "validate()"', () => {
+    expect(new StrongConfig().validate).toBeInstanceOf(Function)
+  })
+
+  it('strongConfig.load() calls imported load() and returns its result', () => {
+    const strongConfig = new StrongConfig()
+
+    const result = strongConfig.load()
+
+    expect(mockedLoad).toHaveBeenCalledTimes(1)
+    expect(result).toStrictEqual(mockedConfig)
+  })
+
+  it('strongConfig.validate() calls imported validate() and returns its result', () => {
+    const strongConfig = new StrongConfig()
+
+    const result = strongConfig.validate(
+      'path/to/schema.json',
+      'some/config/path'
+    )
+
+    expect(mockedValidate).toHaveBeenCalledTimes(1)
+    expect(result).toStrictEqual(mockedValidationResult)
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,43 +15,62 @@ mockedValidate.mockReturnValue(mockedValidationResult)
 import StrongConfig from './index'
 
 describe('StrongConfig class', () => {
-  it('StrongConfig is a class that can be instantiated', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('can be instantiated', () => {
     expect(new StrongConfig()).toBeDefined()
   })
 
-  it('StrongConfig accepts and stores a configuration object', () => {
-    const mockConfiguration = {}
-    const strongConfig = new StrongConfig(mockConfiguration)
+  it('accepts and stores a parameter object', () => {
+    const mockedParams = {}
+    const strongConfig = new StrongConfig(mockedParams)
 
-    expect(strongConfig.configuration).toStrictEqual(mockConfiguration)
+    expect(strongConfig.params).toStrictEqual(mockedParams)
   })
 
-  it('strongConfig exposes "load()"', () => {
+  it('strongConfig instance exposes "load()"', () => {
     expect(new StrongConfig().load).toBeInstanceOf(Function)
   })
 
-  it('strongConfig exposes "validate()"', () => {
+  it('strongConfig instance exposes "validate()"', () => {
     expect(new StrongConfig().validate).toBeInstanceOf(Function)
   })
 
-  it('strongConfig.load() calls imported load() and returns its result', () => {
-    const strongConfig = new StrongConfig()
+  describe('strongConfig.load()', () => {
+    it('calls imported load() and returns its result', () => {
+      const strongConfig = new StrongConfig()
 
-    const result = strongConfig.load()
+      const result = strongConfig.load()
 
-    expect(mockedLoad).toHaveBeenCalledTimes(1)
-    expect(result).toStrictEqual(mockedConfig)
+      expect(mockedLoad).toHaveBeenCalledTimes(1)
+      expect(result).toStrictEqual(mockedConfig)
+    })
+
+    it('memoizes previously loaded config', () => {
+      const strongConfig = new StrongConfig()
+
+      const firstLoadResult = strongConfig.load()
+      const secondLoadResult = strongConfig.load()
+
+      expect(mockedLoad).toHaveBeenCalledTimes(1)
+      expect(firstLoadResult).toStrictEqual(mockedConfig)
+      expect(secondLoadResult).toStrictEqual(mockedConfig)
+    })
   })
 
-  it('strongConfig.validate() calls imported validate() and returns its result', () => {
-    const strongConfig = new StrongConfig()
+  describe('strongConfig.validate()', () => {
+    it('calls imported validate() and returns its result', () => {
+      const strongConfig = new StrongConfig()
 
-    const result = strongConfig.validate(
-      'path/to/schema.json',
-      'some/config/path'
-    )
+      const result = strongConfig.validate(
+        'path/to/schema.json',
+        'some/config/path'
+      )
 
-    expect(mockedValidate).toHaveBeenCalledTimes(1)
-    expect(result).toStrictEqual(mockedValidationResult)
+      expect(mockedValidate).toHaveBeenCalledTimes(1)
+      expect(result).toStrictEqual(mockedValidationResult)
+    })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,26 @@
-export { load } from './load'
-export { validate } from './validate'
+import { load } from './load'
+import { validate } from './validate'
+
+interface Configuration {
+  // TODO: define Configuration interface
+}
+
+export default class StrongConfig {
+  public readonly configuration: Configuration | undefined
+
+  constructor(configuration?: Configuration) {
+    // TODO: validate configuration
+    this.configuration = configuration
+  }
+
+  public load(passedConfig?: MemoizedConfig): ReturnType<typeof load> {
+    return load(passedConfig)
+  }
+
+  public validate(
+    schemaPath: string,
+    ...configPaths: string[]
+  ): ReturnType<typeof validate> {
+    return validate(schemaPath, ...configPaths)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,20 +3,27 @@ import { validate } from './validate'
 
 import { MemoizedConfig } from './types'
 
-interface Configuration {
-  // TODO: define Configuration interface
+interface Parameters {
+  // TODO: define Parameters interface
 }
 
 export = class StrongConfig {
-  public readonly configuration: Configuration | undefined
+  public readonly params: Parameters | undefined
+  private config: MemoizedConfig
 
-  constructor(configuration?: Configuration) {
-    // TODO: validate configuration
-    this.configuration = configuration
+  constructor(params?: Parameters) {
+    // TODO: validate params
+    this.params = params
   }
 
-  public load(passedConfig?: MemoizedConfig): ReturnType<typeof load> {
-    return load(passedConfig)
+  public load(): ReturnType<typeof load> {
+    if (this.config) {
+      return this.config
+    }
+
+    this.config = load()
+
+    return this.config
   }
 
   public validate(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import { load } from './load'
 import { validate } from './validate'
 
+import { MemoizedConfig } from './types'
+
 interface Configuration {
   // TODO: define Configuration interface
 }
 
-export default class StrongConfig {
+export = class StrongConfig {
   public readonly configuration: Configuration | undefined
 
   constructor(configuration?: Configuration) {

--- a/src/load.ts
+++ b/src/load.ts
@@ -5,6 +5,8 @@ import { validateConfig } from './utils/validate-config'
 import { readConfigFile, readSchemaFile } from './utils/read-file'
 import * as sops from './utils/sops'
 
+import { MemoizedConfig, HydratedConfig } from './types'
+
 let memoizedConfig: MemoizedConfig = undefined
 
 export const getMemoizedConfig = (): MemoizedConfig => {

--- a/src/load.ts
+++ b/src/load.ts
@@ -5,31 +5,11 @@ import { validateConfig } from './utils/validate-config'
 import { readConfigFile, readSchemaFile } from './utils/read-file'
 import * as sops from './utils/sops'
 
-import { MemoizedConfig, HydratedConfig } from './types'
+import { HydratedConfig } from './types'
 
-let memoizedConfig: MemoizedConfig = undefined
-
-export const getMemoizedConfig = (): MemoizedConfig => {
-  return memoizedConfig
-}
-
-export const clearMemoizedConfig = (): void => {
-  memoizedConfig = undefined
-}
-
-export const load = (
-  passedConfig: MemoizedConfig = memoizedConfig
-): HydratedConfig => {
+export const load = (): HydratedConfig => {
   if (R.isNil(process.env.RUNTIME_ENVIRONMENT)) {
     throw new Error('process.env.RUNTIME_ENVIRONMENT must be defined.')
-  }
-
-  if (!R.isNil(passedConfig)) {
-    memoizedConfig = {
-      ...passedConfig,
-      runtimeEnvironment: process.env.RUNTIME_ENVIRONMENT,
-    }
-    return memoizedConfig
   }
 
   const configFile = readConfigFile(`./config`, process.env.RUNTIME_ENVIRONMENT)
@@ -48,8 +28,6 @@ export const load = (
 
     generateTypeFromSchema('config/schema.json')
   }
-
-  memoizedConfig = config
 
   return config
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,13 +24,3 @@ export type EncryptedConfig = { sops?: SopsMetadata } & BaseConfig
 export type DecryptedConfig = Omit<BaseConfig, 'sops'>
 export type HydratedConfig = { runtimeEnvironment: string } & DecryptedConfig
 export type MemoizedConfig = HydratedConfig | undefined
-
-export enum FileExtension {
-  JSON = 'json',
-  YAML = 'yaml',
-  YML = 'yml',
-}
-export type File = {
-  contents: EncryptedConfig | Schema
-  filePath: string
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,11 +3,11 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface JSONArray extends Array<JSONValue> {}
 type JSONValue = string | number | boolean | JSONObject | JSONArray
-interface JSONObject {
+export interface JSONObject {
   [x: string]: JSONValue
 }
-type BaseConfig = JSONObject
-type Schema = JSONObject
+export type BaseConfig = JSONObject
+export type Schema = JSONObject
 
 type SopsMetadata = {
   kms: unknown | null
@@ -19,7 +19,18 @@ type SopsMetadata = {
   version: string
   encrypted_suffix?: string | null
 }
-type EncryptedConfig = { sops?: SopsMetadata } & BaseConfig
-type DecryptedConfig = Omit<BaseConfig, 'sops'>
-type HydratedConfig = { runtimeEnvironment: string } & DecryptedConfig
-type MemoizedConfig = HydratedConfig | undefined
+
+export type EncryptedConfig = { sops?: SopsMetadata } & BaseConfig
+export type DecryptedConfig = Omit<BaseConfig, 'sops'>
+export type HydratedConfig = { runtimeEnvironment: string } & DecryptedConfig
+export type MemoizedConfig = HydratedConfig | undefined
+
+export enum FileExtension {
+  JSON = 'json',
+  YAML = 'yaml',
+  YML = 'yml',
+}
+export type File = {
+  contents: EncryptedConfig | Schema
+  filePath: string
+}

--- a/src/utils/get-file-from-path.ts
+++ b/src/utils/get-file-from-path.ts
@@ -2,7 +2,8 @@ import R from 'ramda'
 import fs from 'fs'
 import yaml from 'js-yaml'
 
-import { File, JSONObject } from '../types'
+import { JSONObject } from '../types'
+import { File } from './read-file'
 
 export const readFileToString = (filePath: string): string =>
   fs.readFileSync(filePath).toString()

--- a/src/utils/get-file-from-path.ts
+++ b/src/utils/get-file-from-path.ts
@@ -2,7 +2,7 @@ import R from 'ramda'
 import fs from 'fs'
 import yaml from 'js-yaml'
 
-import { File } from './read-file'
+import { File, JSONObject } from '../types'
 
 export const readFileToString = (filePath: string): string =>
   fs.readFileSync(filePath).toString()

--- a/src/utils/hydrate-config.ts
+++ b/src/utils/hydrate-config.ts
@@ -1,6 +1,8 @@
 import R from 'ramda'
 import { substituteWithEnv } from './substitute-with-env'
 
+import { DecryptedConfig, HydratedConfig } from '../types'
+
 export type InnerHydrateFunction = (
   decryptedConfig: DecryptedConfig
 ) => HydratedConfig

--- a/src/utils/read-file.test.ts
+++ b/src/utils/read-file.test.ts
@@ -1,7 +1,8 @@
 jest.mock('./find-files')
 jest.mock('./get-file-from-path')
-import { File, findConfigFiles, findFiles } from './find-files'
+import { findConfigFiles, findFiles } from './find-files'
 import { getFileFromPath } from './get-file-from-path'
+import { File } from '../types'
 
 const mockedFindConfigFiles = findConfigFiles as jest.MockedFunction<
   typeof findConfigFiles
@@ -50,7 +51,9 @@ describe('readConfigFile()', () => {
       'config/anotherfile.yaml',
     ])
 
-    expect(() => readConfigFile('config')).toThrow(/Exactly one must exist/)
+    expect(() => readConfigFile('config', 'development')).toThrow(
+      /Exactly one must exist/
+    )
   })
 
   it('reads file when exactly one config is found', () => {
@@ -70,13 +73,13 @@ describe('readSchemaFile()', () => {
   })
 
   it('returns undefined and does not throw Error when files array is empty', () => {
-    findFiles.mockReturnValueOnce([])
+    mockedFindFiles.mockReturnValueOnce([])
 
     expect(readSchemaFile('schema')).toBeUndefined()
   })
 
   it('throws when files array contains more than one match', () => {
-    findFiles.mockReturnValueOnce([
+    mockedFindFiles.mockReturnValueOnce([
       ...mockedConfigFilePaths,
       'config/anotherschema.json',
     ])

--- a/src/utils/read-file.test.ts
+++ b/src/utils/read-file.test.ts
@@ -1,8 +1,7 @@
 jest.mock('./find-files')
 jest.mock('./get-file-from-path')
-import { findConfigFiles, findFiles } from './find-files'
+import { findConfigFiles, findFiles, File } from './find-files'
 import { getFileFromPath } from './get-file-from-path'
-import { File } from '../types'
 
 const mockedFindConfigFiles = findConfigFiles as jest.MockedFunction<
   typeof findConfigFiles

--- a/src/utils/read-file.ts
+++ b/src/utils/read-file.ts
@@ -4,7 +4,17 @@ import path from 'path'
 import { findConfigFiles, findFiles } from './find-files'
 import { getFileFromPath } from './get-file-from-path'
 
-import { File, FileExtension } from '../types'
+import { EncryptedConfig, Schema } from '../types'
+
+export enum FileExtension {
+  JSON = 'json',
+  YAML = 'yaml',
+  YML = 'yml',
+}
+export type File = {
+  contents: EncryptedConfig | Schema
+  filePath: string
+}
 
 export const getFileExtensionPattern = (): string =>
   `{${Object.values(FileExtension).join(',')}}`

--- a/src/utils/read-file.ts
+++ b/src/utils/read-file.ts
@@ -4,15 +4,7 @@ import path from 'path'
 import { findConfigFiles, findFiles } from './find-files'
 import { getFileFromPath } from './get-file-from-path'
 
-export enum FileExtension {
-  JSON = 'json',
-  YAML = 'yaml',
-  YML = 'yml',
-}
-export type File = {
-  contents: EncryptedConfig | Schema
-  filePath: string
-}
+import { File, FileExtension } from '../types'
 
 export const getFileExtensionPattern = (): string =>
   `{${Object.values(FileExtension).join(',')}}`

--- a/src/utils/sops.ts
+++ b/src/utils/sops.ts
@@ -2,6 +2,8 @@ import execa from 'execa'
 import yaml from 'js-yaml'
 import R from 'ramda'
 
+import { EncryptedConfig, DecryptedConfig } from '../types'
+
 const hasSopsMetadata = R.has('sops')
 
 const runSopsWithOptions = (options: string[]): string => {

--- a/src/utils/validate-config.ts
+++ b/src/utils/validate-config.ts
@@ -1,5 +1,7 @@
 import Ajv from 'ajv'
 
+import { BaseConfig, Schema } from '../types'
+
 const ajv = new Ajv({ useDefaults: true })
 
 export const validateConfig = (config: BaseConfig, schema: Schema): true => {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -5,6 +5,8 @@ import { findConfigFiles } from './utils/find-files'
 import { getFileFromPath } from './utils/get-file-from-path'
 import { validateConfig } from './utils/validate-config'
 
+import { Schema } from './types'
+
 const validateConfigAgainstSchema = (schema: Schema) => (
   configFilePath: string
 ): true => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noImplicitAny": true,
     "outDir": "./lib",
     "paths": {
-      "*": ["node_modules/*", "src/*"]
+      "*": ["node_modules/*"]
     },
     "resolveJsonModule": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,13 @@
     "noImplicitAny": true,
     "outDir": "./lib",
     "paths": {
-      "*": ["node_modules/*"]
+      "*": ["node_modules/*", "src/*"]
     },
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es6"
+    "target": "es6",
+    "lib": ["es6"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "node_modules"]


### PR DESCRIPTION
Donezo:

- [x] Export class `StrongConfig` instead of two top-level functions `load()` and `validate()`.
- [x] Move state (loaded config) into `StrongConfig` class instance.
- [x] Move types to `src/types.ts`. I learnt that `.d.ts` files define ambient types for non-typescript code bases. So this was the wrong approach. With the new file, we have to export/import types.
- [x] Update tests accordingly

The refactor to class `StrongConfig` is a BREAKING CHANGE

Fixes https://github.com/strong-config/node/issues/7