### PR TITLE
Error msg for invalid options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.53](https://github.com/strong-config/node/compare/v0.2.52...v0.2.53) (2021-01-08)
+
+
+### Features
+
+* **check-encryption:** allow passing multiple config file arguments ([0c4967c](https://github.com/strong-config/node/commit/0c4967c94a015213542a2d10b86847256ff96949))
+* **validate:** allow passing multiple config file arguments ([fba3501](https://github.com/strong-config/node/commit/fba35010fb45f995637efd90f7773b951b50bbae))
+
 ### [0.2.52](https://github.com/strong-config/node/compare/v0.2.51...v0.2.52) (2020-12-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strong-config/node",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "description": "Simple & Secure Config Management for Node.js",
   "repository": "git@github.com:strong-config/node.git",
   "homepage": "https://strong-config.dev",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "shelljs": "^0.8.4",
     "stdout-stderr": "^0.1.13",
     "ts-jest": "^26.1.0",
-    "ts-node": "^8.10.2",
+    "ts-node": "^9.1.1",
     "typescript": "^3.9.5"
   },
   "resolutions": {

--- a/scripts/end-to-end-tests.sh
+++ b/scripts/end-to-end-tests.sh
@@ -14,7 +14,7 @@ set -euxo pipefail
 yarn pack
 mv strong-config*.tgz ..
 cd ..
-mkdir blackbox
+mkdir -p blackbox
 cd blackbox
 yarn init --yes
 yarn add file:$(ls ../strong-config*.tgz) ts-node typescript

--- a/scripts/healthcheck.ts
+++ b/scripts/healthcheck.ts
@@ -98,6 +98,19 @@ async function runIntegrationTests(): Promise<void> {
   }
 }
 
+async function runEndToEndTests(): Promise<void> {
+  const spinner = ora('Running End-to-End Tests...').start()
+
+  try {
+    await run('./scripts/end-to-end-tests.sh')
+
+    spinner.succeed(chalk.bold('End-to-End Tests'))
+  } catch (error) {
+    spinner.fail(chalk.bold('End-to-End Tests'))
+    throw new Error(error)
+  }
+}
+
 async function runReleaseScripts(): Promise<void> {
   const spinner = ora('Running Release Scripts...').start()
 
@@ -145,6 +158,7 @@ async function main(): Promise<void> {
   await runUnitTests()
   await runBuild()
   await runIntegrationTests()
+  await runEndToEndTests()
   await runReleaseScripts()
   await printTodos()
 }

--- a/src/cli/check-encryption.ts
+++ b/src/cli/check-encryption.ts
@@ -11,7 +11,7 @@ export class CheckEncryption extends Command {
   static description =
     'check that config file(s) with secrets are safely encrypted'
 
-  static strict = true
+  static strict = false
 
   static flags = {
     help: Flags.help({
@@ -133,12 +133,13 @@ export class CheckEncryption extends Command {
   }
 
   async run(): Promise<void> {
-    const { args } = this.parse(CheckEncryption)
+    const { argv } = this.parse(CheckEncryption)
 
-    if (args.config_file) {
-      this.checkOneConfigFile(args.config_file)
-        ? process.exit(0)
-        : process.exit(1)
+    if (argv.length > 0) {
+      argv.forEach((configPath) => {
+        this.checkOneConfigFile(configPath) || process.exit(1)
+      })
+      process.exit(0)
     } else {
       await this.checkAllConfigFiles()
     }

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -53,7 +53,7 @@ export const validateOneConfigFile = (
 export class Validate extends Command {
   static description = 'validate config file(s) against a JSON schema'
 
-  static strict = true
+  static strict = false
 
   static flags = {
     'config-root': Flags.string({
@@ -118,7 +118,7 @@ export class Validate extends Command {
   }
 
   async run(): Promise<void> {
-    const { args, flags } = this.parse(Validate)
+    const { argv, flags } = this.parse(Validate)
 
     const spinner = ora(`Loading schema from: ${flags['config-root']}`).start()
     const schema = loadSchema(flags['config-root'])
@@ -130,10 +130,11 @@ export class Validate extends Command {
       process.exit(1)
     }
 
-    if (args.config_file) {
-      validateOneConfigFile(args.config_file, schema)
-        ? process.exit(0)
-        : process.exit(1)
+    if (argv.length > 0) {
+      argv.forEach((configPath) => {
+        validateOneConfigFile(configPath, schema) || process.exit(1)
+      })
+      process.exit(0)
     } else {
       ;(await this.validateAllConfigFiles(flags['config-root'], schema))
         ? process.exit(0)

--- a/src/core/index.test.ts
+++ b/src/core/index.test.ts
@@ -34,7 +34,7 @@ describe('StrongConfig.constructor()', () => {
     jest.restoreAllMocks()
   })
 
-  it('can be instantiated without constructor arguments', () => {
+  it('can be instantiated without any options', () => {
     expect(new StrongConfig()).toBeDefined()
   })
 
@@ -64,6 +64,8 @@ describe('StrongConfig.constructor()', () => {
 
   it('throws if the passed options object is invalid', () => {
     const invalidOptions = { i: 'am', super: 'invalid' }
+    const originalConsoleError = console.error
+    console.error = jest.fn()
     const validate = jest.spyOn(StrongConfig.prototype, 'validate')
 
     expect(
@@ -75,6 +77,11 @@ describe('StrongConfig.constructor()', () => {
       { ...defaultOptions, ...invalidOptions },
       optionsSchema
     )
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringMatching("Invalid options passed to 'new StrongConfig")
+    )
+    console.error = originalConsoleError
   })
 
   it('stores the validated options object', () => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -74,9 +74,6 @@ export = class StrongConfig {
       ? { ...defaultOptions, ...userOptions }
       : defaultOptions
 
-    this.validate(options, optionsSchema)
-    this.options = options
-
     if (
       !process.env[options.runtimeEnvName] ||
       typeof process.env[options.runtimeEnvName] !== 'string'
@@ -92,8 +89,22 @@ export = class StrongConfig {
       )
     }
 
+    try {
+      this.validate(options, optionsSchema)
+      this.options = options
+    } catch (error) {
+      console.error(
+        `Invalid options passed to 'new StrongConfig({ ${JSON.stringify(
+          options,
+          undefined,
+          2
+        )}})'`
+      )
+      throw new Error(error)
+    }
+
     // Typecasting to string is safe as we've determined it's a string in the previous if-statement
-    this.runtimeEnv = process.env[options.runtimeEnvName] as string
+    this.runtimeEnv = process.env[this.options.runtimeEnvName] as string
 
     // See explanation for why 'null' in comments for getSchema() method
     // eslint-disable-next-line unicorn/no-null
@@ -108,8 +119,8 @@ export = class StrongConfig {
       debug('Config is valid')
 
       if (
-        options.generateTypes &&
-        process.env[options.runtimeEnvName] === 'development'
+        this.options.generateTypes &&
+        process.env[this.options.runtimeEnvName] === 'development'
       ) {
         this.generateTypes()
       }
@@ -119,7 +130,7 @@ export = class StrongConfig {
        * always encourage users to define a schema for their config.
        */
       console.info(
-        `⚠️ No schema file found under '${options.configRoot}/schema.json'. We recommend creating a schema so Strong Config can ensure your config is valid.`
+        `⚠️ No schema file found under '${this.options.configRoot}/schema.json'. We recommend creating a schema so Strong Config can ensure your config is valid.`
       )
     }
   }

--- a/src/e2e/load-commonjs.js
+++ b/src/e2e/load-commonjs.js
@@ -3,7 +3,7 @@ const { inspect } = require('util')
 const StrongConfig = require('@strong-config/node')
 
 const strongConfig = new StrongConfig({
-  configRoot: 'example/',
+  configRoot: 'example',
 })
 
 const config = strongConfig.getConfig()

--- a/src/e2e/validate.ts
+++ b/src/e2e/validate.ts
@@ -3,7 +3,7 @@ import StrongConfig = require('@strong-config/node')
 import type { Schema } from '../types'
 
 const strongConfig = new StrongConfig({
-  configRoot: 'example/',
+  configRoot: 'example',
 })
 
 const config = strongConfig.getConfig()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,6 +2127,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-env@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
@@ -6956,12 +6961,13 @@ ts-jest@^26.1.0:
     semver "7.x"
     yargs-parser "18.x"
 
-ts-node@^8.10.2:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
   dependencies:
     arg "^4.1.0"
+    create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
     source-map-support "^0.5.17"


### PR DESCRIPTION
Previously, it was easy to confuse the error messages for `options-validation-failed` and `config-validation-failed` because they were looking almost identical.

This PR adds a custom error message for when passing invalid options upon initializing strong conflict.